### PR TITLE
[DNM] Ignore errors in calls to CDB_QueryTables_Updated_At

### DIFF
--- a/lib/querytables.js
+++ b/lib/querytables.js
@@ -37,10 +37,10 @@ module.exports.getAffectedTablesFromQuery = function (pg, sql, callback) {
             'SELECT * FROM CDB_QueryTables_Updated_At($windshaft$' + prepareSql(sql) + '$windshaft$)';
 
     pg.query(query, function handleAffectedTablesAndLastUpdatedTimeRows (err, result) {
-        if (err) {
-            var msg = err.message ? err.message : err;
-            return callback(new Error('could not fetch affected tables or last updated time: ' + msg));
-        }
+        // if (err) {
+        //     var msg = err.message ? err.message : err;
+        //     return callback(new Error('could not fetch affected tables or last updated time: ' + msg));
+        // }
         result = result || {};
         var rows = result.rows || [];
 


### PR DESCRIPTION
In some FDW scenarios it fails because it looks for the
CDB_TableMetadata in the foreign schema and does not find it.

This is a hack to make it work at the expense of caching.