### PR TITLE
fix  cdb_table_metadata subquery

### DIFF
--- a/lib/querytables.js
+++ b/lib/querytables.js
@@ -233,7 +233,7 @@ function getTablesMetadata (pg, tableArray, callback) {
                 (SELECT md.updated_at FROM cartodb.CDB_TableMetadata md WHERE md.tabname = reloid) AS updated_at,
                 (CASE   WHEN relkind != 'f' THEN current_database()
                         ELSE (
-                            SELECT option_value AS dbname FROM cdb_table_oids, pg_options_to_table((
+                            SELECT option_value AS dbname FROM pg_options_to_table((
                                 SELECT fs.srvoptions
                                 FROM pg_foreign_table ft
                                 LEFT JOIN pg_foreign_server fs ON ft.ftserver = fs.oid


### PR DESCRIPTION
Without this fix, i get this error with multiple foreign table :
> ERROR: more than one row returned by a subquery used as an expression